### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/198650/a4e45f5b-0683-468f-8cc4-baa565e83e6a/fab910d7-749c-4b70-b4f7-3cfc580d331d/_apis/work/boardbadge/7994c0d2-e9e1-428c-83e9-b46b6b995471)](https://dev.azure.com/198650/a4e45f5b-0683-468f-8cc4-baa565e83e6a/_boards/board/t/fab910d7-749c-4b70-b4f7-3cfc580d331d/Microsoft.RequirementCategory)
 # Tic Tac Toe Game
 
 Let's learn about CD while using GitHub Actions and the GitHub Package Registry!


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://dev.azure.com/198650/a4e45f5b-0683-468f-8cc4-baa565e83e6a/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.